### PR TITLE
Bug: resolved type error with Professor OAK's Lab

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -817,7 +817,7 @@ while not exit:
 			sg('Many Pokémon trainers hold him in high regard!')
 		elif option == '3':
 			sg('\nOAK: You\'ve caught a total of...')
-			sg(f'\n{sum(1 if i["caught"] else 0 for i in save["dex"])} Pokémon!')
+			sg(f'\n{sum(1 if save["dex"][i]["caught"] else 0 for i in save["dex"])} Pokémon!')
 		elif option == '4':
 			sg('\nThere\' an email message here:')
 			sg('"Calling all Pokémon trainers!\nThe elite trainers of Pokémon League are ready to take on all comers! Bring your best Pokémon and see how you rate as a trainer!\nPOKEMON LEAGUE HQ INDIGO PLATEAU\nPS: Professor OAK, please visit us!"')


### PR DESCRIPTION
Resolved the type error as indicated in the issue.

Before:
```
[a] - Go to Pallet Town
[1] - Lab Assistant (Left)
[2] - Lab Assistant (Right)
[3] - Professor OAK
[4] - OAK's Computer

> 3

OAK: You've caught a total of...
Traceback (most recent call last):
File "/home/kali/Desktop/Pokemon-PythonRed-master/app/./main.py", line 820, in
sg(f'\n{sum(1 if i["caught"] else 0 for i in save["dex"])} Pokémon!')
File "/home/kali/Desktop/Pokemon-PythonRed-master/app/./main.py", line 820, in
sg(f'\n{sum(1 if i["caught"] else 0 for i in save["dex"])} Pokémon!')
TypeError: string indices must be integers
```

After:
```
Current Location: OAK's Lab

[a] - Go to Pallet Town
[1] - Lab Assistant (Left)
[2] - Lab Assistant (Right)
[3] - Professor OAK
[4] - OAK's Computer

> 3

OAK: You've caught a total of...

1 Pokémon!
```