### PR TITLE
Colour text fixup

### DIFF
--- a/app/data/map.json
+++ b/app/data/map.json
@@ -178,5 +178,117 @@
                 }
             ]
         }
+    },
+    "route2-s": {
+        "tall-grass": {
+            "51": [
+                {
+                    "pokemon": "RATTATA",
+                    "level": 3
+                },
+                {
+                    "pokemon": "PIDGEY",
+                    "level": 3
+                }
+            ],
+            "39": [
+                {
+                    "pokemon": "PIDGEY",
+                    "level": 4
+                }
+            ],
+            "25": [
+                {
+                    "pokemon": "RATTATA",
+                    "level": 4
+                },
+                {
+                    "pokemon": "PIDGEY",
+                    "level": 5
+                },
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 3
+                }
+            ],
+            "13": [
+                {
+                    "pokemon": "RATTATA",
+                    "level": 2
+                },
+                {
+                    "pokemon": "RATTATA",
+                    "level": 5
+                }
+            ],
+            "11": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 4
+                }
+            ],
+            "3": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 5
+                }
+            ]
+        }
+    },
+    "route2-n": {
+        "tall-grass": {
+            "51": [
+                {
+                    "pokemon": "RATTATA",
+                    "level": 3
+                },
+                {
+                    "pokemon": "PIDGEY",
+                    "level": 3
+                }
+            ],
+            "39": [
+                {
+                    "pokemon": "PIDGEY",
+                    "level": 4
+                }
+            ],
+            "25": [
+                {
+                    "pokemon": "RATTATA",
+                    "level": 4
+                },
+                {
+                    "pokemon": "PIDGEY",
+                    "level": 5
+                },
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 3
+                }
+            ],
+            "13": [
+                {
+                    "pokemon": "RATTATA",
+                    "level": 2
+                },
+                {
+                    "pokemon": "RATTATA",
+                    "level": 5
+                }
+            ],
+            "11": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 4
+                }
+            ],
+            "3": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 5
+                }
+            ]
+        }
     }
 }

--- a/app/data/map.json
+++ b/app/data/map.json
@@ -145,41 +145,7 @@
             ]
         }
     },
-    "viridian-s": {
-        "old-rod": {
-            "256": [
-                {
-                    "pokemon": "MAGIKARP",
-                    "level": 5
-                }
-            ]
-        },
-        "good-rod": {
-            "128": [
-                {
-                    "pokemon": "GOLDEEN",
-                    "level": 10
-                },
-                {
-                    "pokemon": "POLIWAG",
-                    "level": 10
-                }
-            ]
-        },
-        "super-rod": {
-            "128": [
-                {
-                    "pokemon": "TENTACOOL",
-                    "level": 15
-                },
-                {
-                    "pokemon": "POLIWAG",
-                    "level": 15
-                }
-            ]
-        }
-    },
-    "viridian-n": {
+    "viridian": {
         "old-rod": {
             "256": [
                 {

--- a/app/data/map.json
+++ b/app/data/map.json
@@ -290,5 +290,229 @@
                 }
             ]
         }
+    },
+    "viridian-forest-s": {
+        "tall-grass": {
+            "51": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 5
+                }
+            ],
+            "39": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 3
+                }
+            ],
+            "25": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 5
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 6
+                }
+            ],
+            "13": [
+                {
+                    "pokemon": "METAPOD",
+                    "level": 4
+                },
+                {
+                    "pokemon": "CATERPIE",
+                    "level": 3
+                }
+            ],
+            "11": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 3
+                }
+            ],
+            "3": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 5
+                }
+            ]
+        }
+    },
+    "viridian-forest-w": {
+        "tall-grass": {
+            "51": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 5
+                }
+            ],
+            "39": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 3
+                }
+            ],
+            "25": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 5
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 6
+                }
+            ],
+            "13": [
+                {
+                    "pokemon": "METAPOD",
+                    "level": 4
+                },
+                {
+                    "pokemon": "CATERPIE",
+                    "level": 3
+                }
+            ],
+            "11": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 3
+                }
+            ],
+            "3": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 5
+                }
+            ]
+        }
+    },
+    "viridian-forest-e": {
+        "tall-grass": {
+            "51": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 5
+                }
+            ],
+            "39": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 3
+                }
+            ],
+            "25": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 5
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 6
+                }
+            ],
+            "13": [
+                {
+                    "pokemon": "METAPOD",
+                    "level": 4
+                },
+                {
+                    "pokemon": "CATERPIE",
+                    "level": 3
+                }
+            ],
+            "11": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 3
+                }
+            ],
+            "3": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 5
+                }
+            ]
+        }
+    },
+    "viridian-forest-n": {
+        "tall-grass": {
+            "51": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 5
+                }
+            ],
+            "39": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 3
+                }
+            ],
+            "25": [
+                {
+                    "pokemon": "WEEDLE",
+                    "level": 5
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 4
+                },
+                {
+                    "pokemon": "KAKUNA",
+                    "level": 6
+                }
+            ],
+            "13": [
+                {
+                    "pokemon": "METAPOD",
+                    "level": 4
+                },
+                {
+                    "pokemon": "CATERPIE",
+                    "level": 3
+                }
+            ],
+            "11": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 3
+                }
+            ],
+            "3": [
+                {
+                    "pokemon": "PIKACHU",
+                    "level": 5
+                }
+            ]
+        }
     }
 }

--- a/app/main.py
+++ b/app/main.py
@@ -79,10 +79,7 @@ def reset_sp(speed) -> None:
 			if char == '`':
 				if not coloured:
 					colour_char = True
-				if coloured:
-					coloured = False
-				else:
-					coloured = True
+				coloured = not coloured
 				continue
 			elif coloured and char == '[':
 				colour_char = True
@@ -98,6 +95,7 @@ def reset_sp(speed) -> None:
 			stdout.flush()
 		if g:
 			getch()
+
 	def sg(text) -> None:
 		sp(text, g=True)
 reset_sp(speed=text[text_speed])

--- a/app/main.py
+++ b/app/main.py
@@ -1333,7 +1333,7 @@ while not exit:
 
 	# viridian city
 	elif save['location'] == 'viridian':
-		sp('Current Location: Viridian City\n\n[w] - Go to Route 2 (South)\n[a] - Go to Route 22 (East)\n[s] - Go to Route 1 (North)\n[1] - Viridian Pokémon Centre\n[2] - Viridian Pokémart\n[3] - Viridian Pokemon Gym')
+		sp('Current Location: Viridian City\n\n[w] - Go to Route 2 (South)\n[a] - Go to Route 22 (East)\n[s] - Go to Route 1 (North)\n[1] - Viridian Pokémon Centre\n[2] - Viridian Pokémart\n[3] - Viridian Pokemon Gym\n')
 		while option == '':
 			option = get()
 		if option == 'w':
@@ -1376,7 +1376,7 @@ while not exit:
 			menu_open = True
 
 	elif save['location'] == 'route2-s':
-		sp('Current Location: Route 2 (South)\n\n[w] - Go to Viridian Forest (South)\n[s] - Go to Viridian City\n[d] - Go to Route 2 (North)')
+		sp('Current Location: Route 2 (South)\n\n[w] - Go to Viridian Forest (South)\n[s] - Go to Viridian City\n[d] - Go to Route 2 (North)\n')
 		while option == '':
 			option = get()
 		if option == 'w':
@@ -1395,7 +1395,7 @@ while not exit:
 			menu_open = True
 
 	elif save['location'] == 'viridian-forest-s':
-		sp('Current Location: Viridian Forest (South)\n\n[a] - Go to Viridian Forest (West)\n[s] - Go to Route 2 (South)\n[d] - Go to Viridian Forest (East)')
+		sp('Current Location: Viridian Forest (South)\n\n[a] - Go to Viridian Forest (West)\n[s] - Go to Route 2 (South)\n[d] - Go to Viridian Forest (East)\n')
 		while option == '':
 			option = get()
 		if option == 's':
@@ -1414,7 +1414,7 @@ while not exit:
 			menu_open = True
 
 	elif save['location'] == 'viridian-forest-w':
-		sp('Current Location: Viridian Forest (West)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[d] - Go to Viridian Forest (East)')
+		sp('Current Location: Viridian Forest (West)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[d] - Go to Viridian Forest (East)\n')
 		while option == '':
 			option = get()
 		if option == 's':
@@ -1433,7 +1433,7 @@ while not exit:
 			menu_open = True
 
 	elif save['location'] == 'viridian-forest-e':
-		sp('Current Location: Viridian Forest (East)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[a] - Go to Viridian Forest (West)')
+		sp('Current Location: Viridian Forest (East)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[a] - Go to Viridian Forest (West)\n')
 		while option == '':
 			option = get()
 		if option == 's':
@@ -1452,11 +1452,11 @@ while not exit:
 			menu_open = True
 
 	elif save['location'] == 'viridian-forest-n':
-		sp('Current Location: Viridian Forest (North)\n\n[w] - Go to Route 2 (North)\n[a] - Go to Viridian Forest (West)\n[d] - Go to Viridian Forest (East)')
+		sp('Current Location: Viridian Forest (North)\n\n[w] - Go to Route 2 (North)\n[a] - Go to Viridian Forest (West)\n[d] - Go to Viridian Forest (East)\n')
 		while option == '':
 			option = get()
 		if option == 'w':
-			save['location'] = 'route2-n'
+			sg("Coming soon") # Will become save['location'] = 'route2-n'
 			encounter = get_encounter('route2-n', 'tall-grass')
 			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 'a':

--- a/app/main.py
+++ b/app/main.py
@@ -1394,13 +1394,70 @@ while not exit:
 		elif option == 'm':
 			menu_open = True
 
-		elif save['location'] == 'viridian-forest-s':
-			sp('Current Location: Viridian Forest (South)\n\n[a] - Go to Viridian Forest (West)\n[s] - Go to Route 2 (South)\n[d] - Go to Viridian Forest (East)')
+	elif save['location'] == 'viridian-forest-s':
+		sp('Current Location: Viridian Forest (South)\n\n[a] - Go to Viridian Forest (West)\n[s] - Go to Route 2 (South)\n[d] - Go to Viridian Forest (East)')
+		while option == '':
+			option = get()
+		if option == 's':
+			save['location'] = 'route2-s'
+			encounter = get_encounter('route2-s', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'a':
+			save['location'] = 'viridian-forest-w'
+			encounter = get_encounter('viridian-forest-w', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'd':
+			save['location'] = 'viridian-forest-e'
+			encounter = get_encounter('viridian-forest-e', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'm':
+			menu_open = True
+
+	elif save['location'] == 'viridian-forest-w':
+		sp('Current Location: Viridian Forest (West)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[d] - Go to Viridian Forest (East)')
+		while option == '':
+			option = get()
+		if option == 's':
+			save['location'] = 'viridian-forest-s'
+			encounter = get_encounter('viridian-forest-s', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'w':
+			save['location'] = 'viridian-forest-n'
+			encounter = get_encounter('viridian-forest-n', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'd':
+			save['location'] = 'viridian-forest-e'
+			encounter = get_encounter('viridian-forest-e', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'm':
+			menu_open = True
+
+		elif save['location'] == 'viridian-forest-e':
+			sp('Current Location: Viridian Forest (East)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[a] - Go to Viridian Forest (West)')
 			while option == '':
 				option = get()
 			if option == 's':
-				save['location'] = 'route2-s'
-				encounter = get_encounter('route2-s', 'tall-grass')
+				save['location'] = 'viridian-forest-s'
+				encounter = get_encounter('viridian-forest-s', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'w':
+				save['location'] = 'viridian-forest-n'
+				encounter = get_encounter('viridian-forest-n', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'a':
+				save['location'] = 'viridian-forest-w'
+				encounter = get_encounter('viridian-forest-w', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'm':
+				menu_open = True
+
+		elif save['location'] == 'viridian-forest-n':
+			sp('Current Location: Viridian Forest (North)\n\n[w] - Go to Route 2 (North)\n[a] - Go to Viridian Forest (West)\n[d] - Go to Viridian Forest (East)')
+			while option == '':
+				option = get()
+			if option == 'w':
+				save['location'] = 'route2-n'
+				encounter = get_encounter('route2-n', 'tall-grass')
 				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 			elif option == 'a':
 				save['location'] = 'viridian-forest-w'
@@ -1412,63 +1469,6 @@ while not exit:
 				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 			elif option == 'm':
 				menu_open = True
-
-		elif save['location'] == 'viridian-forest-w':
-			sp('Current Location: Viridian Forest (West)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[d] - Go to Viridian Forest (East)')
-			while option == '':
-				option = get()
-			if option == 's':
-				save['location'] = 'viridian-forest-s'
-				encounter = get_encounter('viridian-forest-s', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'w':
-				save['location'] = 'viridian-forest-n'
-				encounter = get_encounter('viridian-forest-n', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'd':
-				save['location'] = 'viridian-forest-e'
-				encounter = get_encounter('viridian-forest-e', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'm':
-				menu_open = True
-
-			elif save['location'] == 'viridian-forest-e':
-				sp('Current Location: Viridian Forest (East)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[a] - Go to Viridian Forest (West)')
-				while option == '':
-					option = get()
-				if option == 's':
-					save['location'] = 'viridian-forest-s'
-					encounter = get_encounter('viridian-forest-s', 'tall-grass')
-					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-				elif option == 'w':
-					save['location'] = 'viridian-forest-n'
-					encounter = get_encounter('viridian-forest-n', 'tall-grass')
-					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-				elif option == 'a':
-					save['location'] = 'viridian-forest-w'
-					encounter = get_encounter('viridian-forest-w', 'tall-grass')
-					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-				elif option == 'm':
-					menu_open = True
-
-			elif save['location'] == 'viridian-forest-n':
-				sp('Current Location: Viridian Forest (North)\n\n[w] - Go to Route 2 (North)\n[a] - Go to Viridian Forest (West)\n[d] - Go to Viridian Forest (East)')
-				while option == '':
-					option = get()
-				if option == 'w':
-					save['location'] = 'route2-n'
-					encounter = get_encounter('route2-n', 'tall-grass')
-					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-				elif option == 'a':
-					save['location'] = 'viridian-forest-w'
-					encounter = get_encounter('viridian-forest-w', 'tall-grass')
-					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-				elif option == 'd':
-					save['location'] = 'viridian-forest-e'
-					encounter = get_encounter('viridian-forest-e', 'tall-grass')
-					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-				elif option == 'm':
-					menu_open = True
 
 	# invalid location
 	else:

--- a/app/main.py
+++ b/app/main.py
@@ -823,7 +823,7 @@ def display_pokemart(loc) -> None: # sourcery skip: low-code-quality
 				except KeyError:
 					in_bag = 0
 				sp(f'\n{pokemart[loc][int(choice)-1]}: ¥{"{:,}".format(items[pokemart[loc][int(choice)-1]]["sell_price"])} (in bag: {in_bag})') # type: ignore
-				sp(items[pokemart[loc][int(choice)-1]]["description"])
+				sp(items[pokemart[loc][int(choice)-1]]["description"]) # type: ignore
 				sp("How many would you like to sell(1-99)? (press 'e' to go back)\n")
 				while not amount:
 					while not amount:
@@ -869,7 +869,7 @@ def display_pokemart(loc) -> None: # sourcery skip: low-code-quality
 					in_bag = 0
 
 				sp(f'\n{pokemart[loc][int(choice)-1]}: ¥{"{:,}".format(items[pokemart[loc][int(choice)-1]]["price"])} (in bag: {in_bag})') # type: ignore
-				sp(items[pokemart[loc][int(choice)-1]]["description"])
+				sp(items[pokemart[loc][int(choice)-1]]["description"]) # type: ignore
 				sp("How many would you like to buy(1-99)? (press 'e' to go back)\n")
 				while not amount:
 					while not amount:

--- a/app/main.py
+++ b/app/main.py
@@ -1456,7 +1456,7 @@ while not exit:
 		while option == '':
 			option = get()
 		if option == 'w':
-			sg("Coming soon") # Will become save['location'] = 'route2-n'
+			save['location'] = 'route2-n'
 			encounter = get_encounter('route2-n', 'tall-grass')
 			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 'a':
@@ -1466,6 +1466,19 @@ while not exit:
 		elif option == 'd':
 			save['location'] = 'viridian-forest-e'
 			encounter = get_encounter('viridian-forest-e', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'm':
+			menu_open = True
+
+	elif save['location'] == "route2-n":
+		sp('Current Location: Route 2 (North)\n\n[w] - Go to Pewter City\n[s] - Go to Viridian Forest (North)\n')
+		while option == '':
+			option = get()
+		if option == 'w':
+			sg("Coming soon") # Will become save['location'] = 'pewter'
+		elif option == 's':
+			save['location'] = 'viridian-forest-n'
+			encounter = get_encounter('viridian-forest-n', 'tall-grass')
 			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 'm':
 			menu_open = True

--- a/app/main.py
+++ b/app/main.py
@@ -1319,7 +1319,7 @@ while not exit:
 		while option == '':
 			option = get()
 		if option == 'w':
-			save['location'] = 'viridian-s'
+			save['location'] = 'viridian'
 		elif option == 's':
 			save['location'] = 'route1-s'
 			encounter = get_encounter('route1-s', 'tall-grass')
@@ -1329,14 +1329,14 @@ while not exit:
 		else:
 			sp('\nInvalid answer!')
 
-	# viridian city - south
-	elif save['location'] == 'viridian-s':
-		sp('Current Location: Viridian City (South)\n\n[w] - Go to Viridian City (North)\n[a] - Go to Route 22 (East)\n[s] - Go to Route 1 (North)\n[1] - Viridian Pokémon Centre\n[2] - Viridian Pokémart\n')
+	# viridian city
+	elif save['location'] == 'viridian':
+		sp('Current Location: Viridian City\n\n[w] - Go to Route 2 (South)\n[a] - Go to Route 22 (East)\n[s] - Go to Route 1 (North)\n[1] - Viridian Pokémon Centre\n[2] - Viridian Pokémart\n[3] - Viridian Pokemon Gym')
 		while option == '':
 			option = get()
 		if option == 'w':
 			if save['flag']['delivered_package']:
-				sg('\nComing soon!') # will become: save['location'] = 'viridian-n'
+				sg('\nComing soon!') # will become: save['location'] = 'route2-s'
 			else:
 				sg('\nAn old man is blocking the way, accompanied by an apologetic young lady.')
 				sg('\nMAN: Hey you, get off my property!')
@@ -1348,7 +1348,7 @@ while not exit:
 			save['location'] = 'route1-n'
 		elif option == '1':
 			heal()
-			save['recent_center'] = 'viridian-s'
+			save['recent_center'] = 'viridian'
 		elif option == '2':
 			if save['flag']['delivered_package']:
 				display_pokemart('viridian')
@@ -1360,6 +1360,12 @@ while not exit:
 				save['bag']['Oak\'s Parcel'] = 1
 				sg(f'\n({save["name"]} recieved Oak\'s Parcel!)\n')
 				sg('\nCLERK: Okay! Say hi to the Professor for me!')
+		elif option == '3':
+			if save['badges']['Boulder'] and save['badges']['Cascade'] and save['badges']['Volcano'] and save['badges']['Marsh'] and save['badges']['Rainbow'] and save['badges']['Soul'] and save['badges']['Thunder']:
+				save['location'] = 'viridian-gym'
+			else:
+				sg("\nThe gym is closed")
+				sg('\nYou won\'t be able to enter until later.')
 		elif option == 'm':
 			menu_open = True
 

--- a/app/main.py
+++ b/app/main.py
@@ -1171,6 +1171,8 @@ while not exit:
 		if option == 'w':
 			if save['flag']['chosen_starter']:
 				save['location'] = 'route1-s'
+				encounter = get_encounter('route1-s', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 			else:
 				sg('\nYou take a step into the tall grass north of Pallet Town.')
 				sg('...')
@@ -1298,15 +1300,14 @@ while not exit:
 
 	# route 1 - south
 	elif save['location'] == 'route1-s':
-		encounter = get_encounter('route1-s', 'tall-grass')
-		battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-
 		if not save['flag']['been_to_route_1']: save['flag']['been_to_route_1'] = True
 		sp('Current Location: Route 1 (South)\n\n[w] - Go to Route 1 (North)\n[s] - Go to Pallet Town\n')
 		while option == '':
 			option = get()
 		if option == 'w':
 			save['location'] = 'route1-n'
+			encounter = get_encounter('route1-n', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 's':
 			save['location'] = 'pallet'
 		elif option == 'm':
@@ -1316,9 +1317,6 @@ while not exit:
 
 	# route 1 - north
 	elif save['location'] == 'route1-n':
-		encounter = get_encounter('route1-n', 'tall-grass')
-		battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-
 		sp('Current Location: Route 1 (North)\n\n[w] - Go to Viridian City\n[s] - Go to Route 1 (South)\n')
 		while option == '':
 			option = get()
@@ -1326,6 +1324,8 @@ while not exit:
 			save['location'] = 'viridian'
 		elif option == 's':
 			save['location'] = 'route1-s'
+			encounter = get_encounter('route1-s', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 'm':
 			menu_open = True
 		else:
@@ -1348,6 +1348,8 @@ while not exit:
 			sg('\nComing soon!')
 		elif option == 's':
 			save['location'] = 'route1-n'
+			encounter = get_encounter('route1-n', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == '1':
 			heal()
 			save['recent_center'] = 'viridian'
@@ -1372,7 +1374,8 @@ while not exit:
 			menu_open = True
 
 	elif save['location'] == 'route2-s':
-		# TODO: Encounter
+		encounter = get_encounter('route2-s', 'tall-grass')
+		battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		sp('Current Location: Route 2 (South)\n\n[w] - Go to Viridian Forest (South)\n[s] - Go to Viridian City\n[d] - Go to Route 2 (North)')
 		while option == '':
 			option = get()

--- a/app/main.py
+++ b/app/main.py
@@ -1339,6 +1339,8 @@ while not exit:
 		if option == 'w':
 			if save['flag']['delivered_package']:
 				save['location'] = 'route2-s'
+				encounter = get_encounter('route2-s', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 			else:
 				sg('\nAn old man is blocking the way, accompanied by an apologetic young lady.')
 				sg('\nMAN: Hey you, get off my property!')
@@ -1374,23 +1376,100 @@ while not exit:
 			menu_open = True
 
 	elif save['location'] == 'route2-s':
-		encounter = get_encounter('route2-s', 'tall-grass')
-		battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		sp('Current Location: Route 2 (South)\n\n[w] - Go to Viridian Forest (South)\n[s] - Go to Viridian City\n[d] - Go to Route 2 (North)')
 		while option == '':
 			option = get()
 		if option == 'w':
-			sp('\nComing Soon')# Will become: save['location'] = 'viridian-forest-s'
+			save['location'] = 'viridian-forest-s'
+			encounter = get_encounter('viridian-forest-s', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 's':
 			save['location'] = 'viridian'
 		elif option == 'd':
 			if save['hms']['cut']:
-				save['location'] = 'route2-n'
+				save['location'] = 'route2-w'
 			else:
 				sg('\nThere is a tree in the way')
 				sg('\nMaybe a Pokémon could cut it down?')
 		elif option == 'm':
 			menu_open = True
+
+		elif save['location'] == 'viridian-forest-s':
+			sp('Current Location: Viridian Forest (South)\n\n[a] - Go to Viridian Forest (West)\n[s] - Go to Route 2 (South)\n[d] - Go to Viridian Forest (East)')
+			while option == '':
+				option = get()
+			if option == 's':
+				save['location'] = 'route2-s'
+				encounter = get_encounter('route2-s', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'a':
+				save['location'] = 'viridian-forest-w'
+				encounter = get_encounter('viridian-forest-w', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'd':
+				save['location'] = 'viridian-forest-e'
+				encounter = get_encounter('viridian-forest-e', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'm':
+				menu_open = True
+
+		elif save['location'] == 'viridian-forest-w':
+			sp('Current Location: Viridian Forest (West)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[d] - Go to Viridian Forest (East)')
+			while option == '':
+				option = get()
+			if option == 's':
+				save['location'] = 'viridian-forest-s'
+				encounter = get_encounter('viridian-forest-s', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'w':
+				save['location'] = 'viridian-forest-n'
+				encounter = get_encounter('viridian-forest-n', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'd':
+				save['location'] = 'viridian-forest-e'
+				encounter = get_encounter('viridian-forest-e', 'tall-grass')
+				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+			elif option == 'm':
+				menu_open = True
+
+			elif save['location'] == 'viridian-forest-e':
+				sp('Current Location: Viridian Forest (East)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[a] - Go to Viridian Forest (West)')
+				while option == '':
+					option = get()
+				if option == 's':
+					save['location'] = 'viridian-forest-s'
+					encounter = get_encounter('viridian-forest-s', 'tall-grass')
+					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+				elif option == 'w':
+					save['location'] = 'viridian-forest-n'
+					encounter = get_encounter('viridian-forest-n', 'tall-grass')
+					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+				elif option == 'a':
+					save['location'] = 'viridian-forest-w'
+					encounter = get_encounter('viridian-forest-w', 'tall-grass')
+					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+				elif option == 'm':
+					menu_open = True
+
+			elif save['location'] == 'viridian-forest-n':
+				sp('Current Location: Viridian Forest (North)\n\n[w] - Go to Route 2 (North)\n[a] - Go to Viridian Forest (West)\n[d] - Go to Viridian Forest (East)')
+				while option == '':
+					option = get()
+				if option == 'w':
+					save['location'] = 'route2-n'
+					encounter = get_encounter('route2-n', 'tall-grass')
+					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+				elif option == 'a':
+					save['location'] = 'viridian-forest-w'
+					encounter = get_encounter('viridian-forest-w', 'tall-grass')
+					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+				elif option == 'd':
+					save['location'] = 'viridian-forest-e'
+					encounter = get_encounter('viridian-forest-e', 'tall-grass')
+					battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+				elif option == 'm':
+					menu_open = True
+
 	# invalid location
 	else:
 		abort(f'The location "{save["location"]}" is not a valid location.')

--- a/app/main.py
+++ b/app/main.py
@@ -416,7 +416,7 @@ class Pokemon:
 			save['dex'][self.species] = {'seen': True, 'caught': True}
 			save['flag']['type'][self.type] = {'seen': True, 'caught': True}
 			sg(f'\nYou caught {self.name}!')
-			sg(f'\n{self.name} ({self.type}-type) was added to your {location}.')
+			sg(f'\n{self.name} (`{self.type}`-type) was added to your {location}.')
 			return True
 		else:
 			if floor(
@@ -563,7 +563,7 @@ def battle(opponent_party=None, battle_type='wild', name=None, title=None, start
 		opponent_bars = ceil((opponent_party[opponent_current].stats['chp']/(opponent_party[opponent_current].stats['hp']))*bars_length) # type: ignore
 		debug(f'Player bars: {bars}\nOpponent bars: {opponent_bars}')
 		debug(f'Player level: {save["party"][current].level}\nOpponent level: {opponent_party[opponent_current].level}') # type: ignore
-		sp(f'''\n{save["party"][current].name}{' '*(name_length-len(save['party'][current].name))}[{'='*bars}{' '*(bars_length-bars)}] {str(save['party'][current].stats['chp'])}/{save['party'][current].stats['hp']} ({save["party"][current].type}) Lv. {save["party"][current].level}\n{opponent_party[opponent_current].name}{' '*(name_length-len(opponent_party[opponent_current].name))}[{'='*opponent_bars}{' '*(bars_length-opponent_bars)}] {opponent_party[opponent_current].stats['chp']}/{opponent_party[opponent_current].stats['hp']} ({opponent_party[opponent_current].type}) Lv. {opponent_party[opponent_current].level}''') # type: ignore
+		sp(f'''\n{save["party"][current].name}{' '*(name_length-len(save['party'][current].name))}[{'='*bars}{' '*(bars_length-bars)}] {str(save['party'][current].stats['chp'])}/{save['party'][current].stats['hp']} (`{save["party"][current].type}`) Lv. {save["party"][current].level}\n{opponent_party[opponent_current].name}{' '*(name_length-len(opponent_party[opponent_current].name))}[{'='*opponent_bars}{' '*(bars_length-opponent_bars)}] {opponent_party[opponent_current].stats['chp']}/{opponent_party[opponent_current].stats['hp']} (`{opponent_party[opponent_current].type}`) Lv. {opponent_party[opponent_current].level}''') # type: ignore
 		sp(f'\nWhat should {save["party"][current].name} do?\n\n[1] - Attack\n[2] - Switch\n[3] - Item\n[4] - Run\n')
 
 		valid_choice = False
@@ -1121,7 +1121,7 @@ while not exit:
 			sp(f'{save["name"]}\'s Pokédex{dex_string}' if dex_string else '\nYou have no Pokémon in your Pokédex!')
 		elif option == 'p':
 			if save['party']:
-				sp('\n'.join(f'{i.name} ({i.type}-type)\nLevel {i.level} ({i.current_xp}/{str(xp["next"][i.level_type][str(i.level)])} XP to next level)\n{i.stats["chp"]}/{i.stats["hp"]} HP' for i in save['party'])) # type: ignore
+				sp('\n'.join(f'{i.name} (`{i.type}`-type)\nLevel {i.level} ({i.current_xp}/{str(xp["next"][i.level_type][str(i.level)])} XP to next level)\n{i.stats["chp"]}/{i.stats["hp"]} HP' for i in save['party'])) # type: ignore
 			else:
 				sp('Your party is empty!')
 		elif option == 'i':

--- a/app/main.py
+++ b/app/main.py
@@ -1298,14 +1298,15 @@ while not exit:
 
 	# route 1 - south
 	elif save['location'] == 'route1-s':
+		encounter = get_encounter('route1-s', 'tall-grass')
+		battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+
 		if not save['flag']['been_to_route_1']: save['flag']['been_to_route_1'] = True
 		sp('Current Location: Route 1 (South)\n\n[w] - Go to Route 1 (North)\n[s] - Go to Pallet Town\n')
 		while option == '':
 			option = get()
 		if option == 'w':
 			save['location'] = 'route1-n'
-			encounter = get_encounter('route1-n', 'tall-grass')
-			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 's':
 			save['location'] = 'pallet'
 		elif option == 'm':
@@ -1315,15 +1316,16 @@ while not exit:
 
 	# route 1 - north
 	elif save['location'] == 'route1-n':
-		sp('Current Location: Route 1 (North)\n\n[w] - Go to Viridian City (South)\n[s] - Go to Route 1 (South)\n')
+		encounter = get_encounter('route1-n', 'tall-grass')
+		battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+
+		sp('Current Location: Route 1 (North)\n\n[w] - Go to Viridian City\n[s] - Go to Route 1 (South)\n')
 		while option == '':
 			option = get()
 		if option == 'w':
 			save['location'] = 'viridian'
 		elif option == 's':
 			save['location'] = 'route1-s'
-			encounter = get_encounter('route1-s', 'tall-grass')
-			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
 		elif option == 'm':
 			menu_open = True
 		else:
@@ -1336,7 +1338,7 @@ while not exit:
 			option = get()
 		if option == 'w':
 			if save['flag']['delivered_package']:
-				sg('\nComing soon!') # will become: save['location'] = 'route2-s'
+				save['location'] = 'route2-s'
 			else:
 				sg('\nAn old man is blocking the way, accompanied by an apologetic young lady.')
 				sg('\nMAN: Hey you, get off my property!')
@@ -1369,6 +1371,23 @@ while not exit:
 		elif option == 'm':
 			menu_open = True
 
+	elif save['location'] == 'route2-s':
+		# TODO: Encounter
+		sp('Current Location: Route 2 (South)\n\n[w] - Go to Viridian Forest (South)\n[s] - Go to Viridian City\n[d] - Go to Route 2 (North)')
+		while option == '':
+			option = get()
+		if option == 'w':
+			sp('\nComing Soon')# Will become: save['location'] = 'viridian-forest-s'
+		elif option == 's':
+			save['location'] = 'viridian'
+		elif option == 'd':
+			if save['hms']['cut']:
+				save['location'] = 'route2-n'
+			else:
+				sg('\nThere is a tree in the way')
+				sg('\nMaybe a Pokémon could cut it down?')
+		elif option == 'm':
+			menu_open = True
 	# invalid location
 	else:
 		abort(f'The location "{save["location"]}" is not a valid location.')

--- a/app/main.py
+++ b/app/main.py
@@ -1432,43 +1432,43 @@ while not exit:
 		elif option == 'm':
 			menu_open = True
 
-		elif save['location'] == 'viridian-forest-e':
-			sp('Current Location: Viridian Forest (East)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[a] - Go to Viridian Forest (West)')
-			while option == '':
-				option = get()
-			if option == 's':
-				save['location'] = 'viridian-forest-s'
-				encounter = get_encounter('viridian-forest-s', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'w':
-				save['location'] = 'viridian-forest-n'
-				encounter = get_encounter('viridian-forest-n', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'a':
-				save['location'] = 'viridian-forest-w'
-				encounter = get_encounter('viridian-forest-w', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'm':
-				menu_open = True
+	elif save['location'] == 'viridian-forest-e':
+		sp('Current Location: Viridian Forest (East)\n\n[w] - Go to Viridian Forest (North)\n[s] - Go to Viridian Forest (South)\n[a] - Go to Viridian Forest (West)')
+		while option == '':
+			option = get()
+		if option == 's':
+			save['location'] = 'viridian-forest-s'
+			encounter = get_encounter('viridian-forest-s', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'w':
+			save['location'] = 'viridian-forest-n'
+			encounter = get_encounter('viridian-forest-n', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'a':
+			save['location'] = 'viridian-forest-w'
+			encounter = get_encounter('viridian-forest-w', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'm':
+			menu_open = True
 
-		elif save['location'] == 'viridian-forest-n':
-			sp('Current Location: Viridian Forest (North)\n\n[w] - Go to Route 2 (North)\n[a] - Go to Viridian Forest (West)\n[d] - Go to Viridian Forest (East)')
-			while option == '':
-				option = get()
-			if option == 'w':
-				save['location'] = 'route2-n'
-				encounter = get_encounter('route2-n', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'a':
-				save['location'] = 'viridian-forest-w'
-				encounter = get_encounter('viridian-forest-w', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'd':
-				save['location'] = 'viridian-forest-e'
-				encounter = get_encounter('viridian-forest-e', 'tall-grass')
-				battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
-			elif option == 'm':
-				menu_open = True
+	elif save['location'] == 'viridian-forest-n':
+		sp('Current Location: Viridian Forest (North)\n\n[w] - Go to Route 2 (North)\n[a] - Go to Viridian Forest (West)\n[d] - Go to Viridian Forest (East)')
+		while option == '':
+			option = get()
+		if option == 'w':
+			save['location'] = 'route2-n'
+			encounter = get_encounter('route2-n', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'a':
+			save['location'] = 'viridian-forest-w'
+			encounter = get_encounter('viridian-forest-w', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'd':
+			save['location'] = 'viridian-forest-e'
+			encounter = get_encounter('viridian-forest-e', 'tall-grass')
+			battle([Pokemon(encounter['pokemon'], encounter['level'], 'random')])
+		elif option == 'm':
+			menu_open = True
 
 	# invalid location
 	else:

--- a/app/main.py
+++ b/app/main.py
@@ -598,7 +598,7 @@ def battle(opponent_party=None, battle_type='wild', name=None, title=None, start
 
 				for i in range(len(save['party'][current].moves)):
 					move_entry = list(filter(lambda m, i=i: m['name'] == save['party'][current].moves[i]['name'], moves))[0] # type: ignore
-					sp(f'[{i+1}] - {save["party"][current].moves[i]["name"].upper().replace("-"," ")}{" "*(longest_move_name_length-len(save["party"][current].moves[i]["name"].upper().replace("-"," ")))} | {move_entry["type"].upper()}{" "*(longest_type_name_length-len(move_entry["type"].upper()))} - {save["party"][current].moves[i]["pp"]}/{move_entry["pp"]}')
+					sp(f'[{i+1}] - {save["party"][current].moves[i]["name"].upper().replace("-"," ")}{" "*(longest_move_name_length-len(save["party"][current].moves[i]["name"].upper().replace("-"," ")))} | `{move_entry["type"].upper()}`{" "*(longest_type_name_length-len(move_entry["type"].upper()))} - {save["party"][current].moves[i]["pp"]}/{move_entry["pp"]}')
 					options.append(str(i+1))
 				sp(f'[e] - Back\n')
 				valid_choice = False

--- a/app/main.py
+++ b/app/main.py
@@ -55,7 +55,7 @@ colours = {
 	'DARK': '\x1b[38;5;095m',
 	'STEEL': '\x1b[38;5;250m',
 	'FAIRY': '\x1b[38;5;212m',
-	'RESET': '\x1b[0;0m'
+	'RESET': '\x1b[00;0;000m'
 }
 
 # declare timed text output
@@ -71,9 +71,29 @@ def reset_sp(speed) -> None:
 	global sp, sg
 	def sp(text, g=False) -> None:
 		for key in colours.keys():
-			text = text.replace(f'{key}', f'{colours[key]}{key}{colours["RESET"]}')
+			text = text.replace(f'`{key}`', f'`{colours[key]}{key}{colours["RESET"]}`')
+		coloured = False
+		colour_char = False
+		i = 0
 		for char in f'{text}\n':
-			sleep(speed)
+			if char == '`':
+				if not coloured:
+					colour_char = True
+				if coloured:
+					coloured = False
+				else:
+					coloured = True
+				continue
+			elif coloured and char == '[':
+				colour_char = True
+			elif not colour_char:
+				sleep(speed)
+			elif i>=10:
+				i = 0
+				colour_char = False
+				sleep(speed)
+			else:
+				i+=1
 			stdout.write(char)
 			stdout.flush()
 		if g:


### PR DESCRIPTION
As of these commits, to fix problems outlines in Issue #123, types will have to be prefixed and suffixed by a \` (backtick) character for the sp() and sg() functions to add the ANSI colour characters like this (line `419`):
```python
sg(f'\n{self.name} (`{self.type}`-type) was added to your {location}.')
```
rather than this (before):
```python
sg(f'\n{self.name} ({self.type}-type) was added to your {location}.')
```